### PR TITLE
シェーダー周りのエラー修正

### DIFF
--- a/resources/shader/Bullet.frag
+++ b/resources/shader/Bullet.frag
@@ -1,5 +1,6 @@
 #ifdef GL_ES
 precision mediump float;
+precision mediump int;
 #endif
 
 uniform vec2 uWindowSize;

--- a/resources/shader/Bullet.vert
+++ b/resources/shader/Bullet.vert
@@ -1,3 +1,8 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
 uniform vec2 uWindowSize;
 uniform int uBulletCount;
 uniform vec2 uBulletPositions[320];

--- a/resources/shader/Sprite.frag
+++ b/resources/shader/Sprite.frag
@@ -1,5 +1,5 @@
 #ifdef GL_ES
-precision mediump float;
+precision highp float;
 #endif
 
 varying vec2 fragTexCoord;

--- a/resources/shader/Sprite.vert
+++ b/resources/shader/Sprite.vert
@@ -1,3 +1,7 @@
+#ifdef GL_ES
+precision mediump float;
+#endif
+
 uniform vec2 uWindowSize;
 uniform vec2 uTextureSize;
 uniform vec2 uTexturePosition;

--- a/src/asset/Shader.cpp
+++ b/src/asset/Shader.cpp
@@ -113,7 +113,7 @@ bool Shader::IsCompiled(GLuint shader)
     {
         char buffer[512];
         memset(buffer, 0, 512);
-        glGetShaderInfoLog(shader, 512, nullptr, buffer);
+        glGetShaderInfoLog(shader, 511, nullptr, buffer);
         SDL_Log("GLSL compile status: %s", buffer);
         return false;
     }
@@ -128,7 +128,7 @@ bool Shader::IsValidProgram()
     {
         char buffer[512];
         memset(buffer, 0, 512);
-        glGetShaderInfoLog(shaderProgramId, 512, nullptr, buffer);
+        glGetProgramInfoLog(shaderProgramId, 511, nullptr, buffer);
         SDL_Log("GLSL link status: %s", buffer);
         return false;
     }


### PR DESCRIPTION
## 概要
Firefoxで起動すると、シェーダー周りのエラーが発生するので修正。

## 参考URL
- [stack overflow - Using the same uniform variable between two shaders in WebGL](https://stackoverflow.com/questions/61587597/using-the-same-uniform-variable-between-two-shaders-in-webgl)
- [浮動小数点数テクスチャ](https://wgld.org/d/webgl/w070.html)